### PR TITLE
Handle the X-Forwarded-Proto header when building URLs

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -38,7 +38,7 @@ func EndpointFromRequest(r *gohttp.Request) string {
 
 	scheme := "http"
 
-	if r.TLS != nil {
+	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
 		scheme = "https"
 	}
 


### PR DESCRIPTION
When running the IIIF server behind a load balancer that deals with HTTPS and dispatches requests via HTTP internally, the load balancer will add some extra HTTP headers to the request, including [`X-Forwarded-Proto`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto), which states the original protocol used for the request. The server currently returns image IDs (`@id` in JSONs) using `http://` all the time and did not handle this header.